### PR TITLE
fix(server): remove liquidty without token lp type script

### DIFF
--- a/apps/server/src/service/txBuilderService/index.ts
+++ b/apps/server/src/service/txBuilderService/index.ts
@@ -52,12 +52,9 @@ export class CancelRequestTxBuilder {
 }
 
 export class TokenLPTypeScriptBuilder {
-  public build(infoTypeScriptArgs: string, tokenTypeHashes: string[]): Script {
-    const id = infoTypeScriptArgs;
-    const infoType = new Script(PoolInfo.TYPE_CODE_HASH, PoolInfo.TYPE_HASH_TYPE, id);
-
+  public build(poolId: string, tokenTypeHashes: string[]): Script {
     // Generate info lock script
-    const infoTypeHash = infoType.toHash();
+    const infoTypeHash = poolId;
     const pairHash = utils.blake2b(tokenTypeHashes);
     const infoLockArgs = `0x${utils.trim0x(pairHash)}${utils.trim0x(infoTypeHash)}`;
     const infoLock = new Script(PoolInfo.LOCK_CODE_HASH, PoolInfo.LOCK_HASH_TYPE, infoLockArgs);

--- a/apps/server/src/tests/api.ts
+++ b/apps/server/src/tests/api.ts
@@ -6,7 +6,7 @@ import * as commons from '@gliaswap/commons';
 import dotenv from 'dotenv';
 dotenv.config();
 
-import { PoolInfo, TokenHolderFactory } from '../../src/model';
+import { PoolInfo, TokenHolderFactory, Script } from '../../src/model';
 import { txBuilder } from '../../src/service';
 import * as config from '../../src/config';
 import { BizException } from '../bizException';
@@ -52,10 +52,11 @@ const generateToken = (amount: bigint, symbol: string) => {
 const generateLPToken = (amount: bigint, tokenSymbol: string) => {
   const token = TOKEN_HOLDER.getTokenBySymbol(tokenSymbol);
   const infoTypeScriptArgs = PoolInfo.TYPE_ARGS[tokenSymbol];
+  const infoType = new Script(PoolInfo.TYPE_CODE_HASH, PoolInfo.TYPE_HASH_TYPE, infoTypeScriptArgs);
 
   const lpTokenTypeScript = new txBuilder.TxBuilderServiceFactory()
     .tokenLPTypeScript()
-    .build(infoTypeScriptArgs, ['ckb', token.typeHash]);
+    .build(infoType.toHash(), ['ckb', token.typeHash]);
 
   return {
     balance: amount.toString(),


### PR DESCRIPTION
If token lp type script isn't passed, we can generate it from
poolId and token type hashes.