### PR TITLE
refactor(commons): make the interface no longer dependent on web3

### DIFF
--- a/apps/ui/src/components/AssetSelector/GroupedAssetList.tsx
+++ b/apps/ui/src/components/AssetSelector/GroupedAssetList.tsx
@@ -1,7 +1,6 @@
 import { SearchOutlined } from '@ant-design/icons';
 import { Asset, ChainType, isCkbSudtAsset, isEthAsset } from '@gliaswap/commons';
 import { Input, Tabs } from 'antd';
-import { useWalletAdapter, Web3ModalAdapter } from 'commons/WalletAdapter';
 import { MetaContainer } from 'components/MetaContainer';
 import { useGliaswap } from 'hooks';
 import i18n from 'i18n';
@@ -72,9 +71,6 @@ export function GroupedAssetList<A extends Asset, K extends Key>(props: GroupedA
   const [searchStatus, setSearchStatus] = useState(SearchStatus.None);
   const [currentTab, setCurrentTab] = useState<ChainType>('Nervos');
   const { api } = useGliaswap();
-  const {
-    raw: { web3 },
-  } = useWalletAdapter<Web3ModalAdapter>();
 
   const sudtAssets = useMemo(() => {
     return assets.filter(isCkbSudtAsset);
@@ -99,7 +95,7 @@ export function GroupedAssetList<A extends Asset, K extends Key>(props: GroupedA
         setSearchResult(asset);
         setSearchStatus(SearchStatus.None);
       } else {
-        const res = await search(val, web3!);
+        const res = await search(val);
         if (res) {
           setSearchResult(res as any);
           setSearchStatus(SearchStatus.Unregistered);
@@ -109,7 +105,7 @@ export function GroupedAssetList<A extends Asset, K extends Key>(props: GroupedA
         }
       }
     },
-    [currentTab, erc20Assets, sudtAssets, web3, api],
+    [currentTab, erc20Assets, sudtAssets, api],
   );
 
   const searchOnChange = useCallback(

--- a/apps/ui/src/contexts/GliaswapAssetContext.tsx
+++ b/apps/ui/src/contexts/GliaswapAssetContext.tsx
@@ -44,13 +44,13 @@ export const Provider: React.FC<ProviderProps> = (props) => {
     return addressToScript(adapter.signer.address);
   }, [adapter]);
 
-  const currentEthAddress = useMemo(() => {
-    return lockScript?.args ?? '';
-  }, [lockScript]);
+  // const currentEthAddress = useMemo(() => {
+  //   return lockScript?.args ?? '';
+  // }, [lockScript]);
 
   const { data, status } = useQuery(
-    ['getAssetsWithBalance', api, lockScript],
-    () => api.getAssetsWithBalance(lockScript!, assetList, currentEthAddress, raw.web3),
+    ['getAssetsWithBalance', lockScript],
+    () => api.getAssetsWithBalance(lockScript!, assetList),
     // TODO: use the env to define the
     { refetchInterval: 10000, enabled: lockScript != null && !!raw.web3 },
   );

--- a/apps/ui/src/contexts/index.tsx
+++ b/apps/ui/src/contexts/index.tsx
@@ -10,7 +10,7 @@ import { ServerGliaswapAPI } from 'suite/api/ServerGliaswapAPI';
 import { BridgeAPI } from 'suite/api/bridgeAPI';
 
 export const GliaswapProvider: React.FC = (props) => {
-  const api: GliaswapAPI = useConstant(() => ServerGliaswapAPI.getInstance());
+  const [api, setAPI] = useState<GliaswapAPI>(() => new ServerGliaswapAPI());
   const bridgeAPI = useConstant(() => BridgeAPI.getInstance());
 
   const adapter = useConstant(() => {
@@ -28,6 +28,8 @@ export const GliaswapProvider: React.FC = (props) => {
       },
     });
   });
+
+  adapter.on('connectStatusChanged', () => setAPI(new ServerGliaswapAPI(adapter.web3)));
 
   const [assetList, setAssetList] = useState<Asset[]>([]);
   useEffect(() => {

--- a/apps/ui/src/contexts/index.tsx
+++ b/apps/ui/src/contexts/index.tsx
@@ -11,6 +11,7 @@ import { BridgeAPI } from 'suite/api/bridgeAPI';
 
 export const GliaswapProvider: React.FC = (props) => {
   const [api, setAPI] = useState<GliaswapAPI>(() => new ServerGliaswapAPI());
+  const [assetList, setAssetList] = useState<Asset[]>([]);
   const bridgeAPI = useConstant(() => BridgeAPI.getInstance());
 
   const adapter = useConstant(() => {
@@ -31,7 +32,6 @@ export const GliaswapProvider: React.FC = (props) => {
 
   adapter.on('connectStatusChanged', () => setAPI(new ServerGliaswapAPI(adapter.web3)));
 
-  const [assetList, setAssetList] = useState<Asset[]>([]);
   useEffect(() => {
     (async () => {
       const hide = message.loading('launching app...', 0);
@@ -39,7 +39,8 @@ export const GliaswapProvider: React.FC = (props) => {
       hide();
       setAssetList(list);
     })();
-  }, [api]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const queryClient = useMemo(() => {
     return new QueryClient();

--- a/apps/ui/src/hooks/useLiquidityPool.ts
+++ b/apps/ui/src/hooks/useLiquidityPool.ts
@@ -13,7 +13,7 @@ export function useLiquidityPoolInfo(queryOptions?: UseQueryOptions<PoolInfo[], 
   const [isLoadingPoolInfo, setIsLoadingPollInfo] = useState(false);
   const { api } = useGliaswap();
 
-  const { data, status } = useQuery(['getLiquidityPools', api], () => api.getLiquidityPools(), queryOptions);
+  const { data, status } = useQuery(['getLiquidityPools', queryOptions], () => api.getLiquidityPools(), queryOptions);
 
   useEffect(() => {
     if (status === 'loading') {

--- a/apps/ui/src/views/Pool/LiquidityExplorer/index.tsx
+++ b/apps/ui/src/views/Pool/LiquidityExplorer/index.tsx
@@ -27,7 +27,7 @@ const LiquidityExplorer = () => {
     return { lock, assets: specsFilter };
   }, [pathname, currentUserLock, specsFilter]);
 
-  const { data, status } = useQuery(['getLiquidityPools', api, poolFilter], async () => {
+  const { data, status } = useQuery(['getLiquidityPools', poolFilter], async () => {
     const pools = await api.getLiquidityPools(poolFilter);
     return pools.filter((pool) => differenceWith(specsFilter, pool.assets, CkbModel.equals).length === 0);
   });

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -2,13 +2,11 @@
   "name": "@gliaswap/commons",
   "version": "0.0.1",
   "main": "./lib/index.js",
-  "dependencies": {
-    "bignumber.js": "^9.0.1",
-    "lodash": "4.17.20"
-  },
   "peerDependencies": {
     "@lay2/pw-core": "^0.3.22",
-    "@nervosnetwork/ckb-types": "^0.39.0"
+    "@nervosnetwork/ckb-types": "^0.39.0",
+    "bignumber.js": "^9.0.1",
+    "lodash": "4.17.20"
   },
   "devDependencies": {
     "@lay2/pw-core": "^0.3.22",

--- a/packages/commons/src/api/GliaswapAPI.ts
+++ b/packages/commons/src/api/GliaswapAPI.ts
@@ -1,6 +1,5 @@
 import { Transaction } from '@lay2/pw-core';
 import CKB from '@nervosnetwork/ckb-sdk-core';
-import Web3 from 'web3';
 import {
   Asset,
   CkbAsset,
@@ -98,12 +97,7 @@ export interface GliaswapAPI {
   /**
    * Get assets with balances, if no `assets` is passed, the built-in AssetWithBalance is returned
    */
-  getAssetsWithBalance: (
-    lock: Script,
-    assets?: Asset[],
-    ethAddr?: string,
-    web3?: Web3,
-  ) => Promise<GliaswapAssetWithBalance[]>;
+  getAssetsWithBalance: (lock: Script, assets?: Asset[]) => Promise<GliaswapAssetWithBalance[]>;
   /**
    * get liquidity pools information
    */
@@ -155,9 +149,11 @@ export interface GliaswapAPI {
     payload: GenerateCancelRequestTransactionPayload,
   ) => Promise<SerializedTransactionToSignWithFee>;
 
+  // might be refactored to `searchAssets`
   searchSUDT: (typeHash: string) => Promise<CkbAsset | undefined>;
 
-  searchERC20: (address: string, web3: Web3) => Promise<EthAsset | undefined>;
+  // might be refactored to `searchAssets`
+  searchERC20: (address: string) => Promise<EthAsset | undefined>;
 
   getPoolInfoWithStatus: (filter: PoolInfoWithStatusFilter) => Promise<Maybe<PoolInfoWithStatus>>;
 }

--- a/packages/commons/src/api/GliaswapAPI.ts
+++ b/packages/commons/src/api/GliaswapAPI.ts
@@ -85,6 +85,11 @@ export interface PoolInfoWithStatusFilter {
 }
 
 export interface GliaswapAPI {
+  /**
+   * @deprecated Since external libraries are out of our control,
+   * a base interface should have as few direct dependencies on third-party libraries as possible,
+   * and therefore may later be refactored to a method in the interface
+   */
   ckb: CKB;
   /**
    * get the default asset list, used as a placeholder


### PR DESCRIPTION
Since external libraries are out of our control,a base interface should have as few direct dependencies on third-party libraries as possible